### PR TITLE
fix VS2019 build

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -20,6 +20,8 @@ cd build
 echo [1/3] Configuring (32-bit)...
 cmake -G "Visual Studio 17 2022" -A Win32 .. 2>&1
 if errorlevel 1 (
+    rd /s /q CMakeFiles
+    del /q CMakeCache.txt
     echo Trying Visual Studio 2019...
     cmake -G "Visual Studio 16 2019" -A Win32 .. 2>&1
     if errorlevel 1 (


### PR DESCRIPTION
this is because cmake is stupid it still creates the CMakeFiles even when VS2022 is not found and the build fails, and when trying VS2019 it will then complain about the cmakefiles mismatching to VS2022 and to delete said CMakeFiles

```
[1/3] Configuring (32-bit)...
CMake Error at CMakeLists.txt:2 (project):
  Generator

    Visual Studio 17 2022

  could not find any instance of Visual Studio.



-- Configuring incomplete, errors occurred!
Trying Visual Studio 2019...
CMake Error: Error: generator : Visual Studio 16 2019
Does not match the generator used previously: Visual Studio 17 2022
Either remove the CMakeCache.txt file and CMakeFiles directory or choose a different binary directory.
ERROR: CMake configure failed.
```
