### PR TITLE
fix: detect !LuaBoost reliably across lua_State swaps and fast logins

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -4380,7 +4380,22 @@ static bool InstallLuaHResizeHook() {
 
 // Main initialization thread.
 static DWORD WINAPI MainThread(LPVOID param) {
-    Sleep(5000);
+    // Brief defensive delay before we install MinHook trampolines and
+    // open the log. The original value was Sleep(5000) (since v1.0,
+    // 33a709e — no documented rationale). Five seconds is long enough
+    // that a fast-logging user can be in the world before any of our
+    // hooks are installed; the FrameScript_Execute hook in particular
+    // misses the world-state lua_State swap, so !LuaBoost's hasDLL()
+    // returns false and the addon installs its Lua-side ThrashGuard
+    // fallback. (This delay is independent of the version.dll proxy's
+    // own LoaderThread Sleep — users running through wow_loader.exe
+    // bypass that proxy and hit only this one.)
+    //
+    // 100 ms is enough for the loader to release the lock acquired
+    // during DllMain and for WoW.exe's CRT init to settle past
+    // anything the original 5 s might have been waiting for, while
+    // staying inside any plausible enter-world path.
+    Sleep(100);
 
     LogOpen();
     Log("========================================");

--- a/src/lua_optimize.cpp
+++ b/src/lua_optimize.cpp
@@ -984,6 +984,49 @@ static void UpdateLuaStats(lua_State* L) {
 }
 
 
+// ================================================================
+//  Detection surface — published immediately on every lua_State swap
+//
+// WHAT: Sets the bare minimum that the !LuaBoost companion addon's
+//       hasDLL() predicate looks for:
+//
+//         type(_G.LuaBoostC_IsLoaded) == "function"
+//             and _G.LUABOOST_DLL_LOADED == true
+//
+// WHY:  SetupLuaInterface is gated behind a 50 ms / 2-frame settle
+//       window after a lua_State swap (login -> world transition,
+//       /reload). The settle exists for the heavy init steps
+//       (allocator, GC, string-table) that previously crashed on a
+//       half-built VM. The detection surface itself needs none of
+//       that. Decoupling them closes the race where PLAYER_LOGIN
+//       fires inside the settle window and the addon concludes the
+//       DLL is absent.
+// HOW:  Direct lua_pushboolean+lua_setfield for the boolean, plus a
+//       trivial FrameScript_Execute snippet to install
+//       LuaBoostC_IsLoaded as a Lua function. Both wrapped in
+//       __try/__except so a half-built lua_State surfaces as a
+//       logged SEH crash rather than an unhandled access violation.
+// ================================================================
+static void PublishDetectionSurface(lua_State* L) {
+    if (!L) return;
+
+    __try {
+        WriteLuaGlobal_Bool(L, "LUABOOST_DLL_LOADED", true);
+
+        if (Api.FrameScript_Execute) {
+            Api.FrameScript_Execute(
+                "function LuaBoostC_IsLoaded() return true end",
+                "LuaOpt", 0);
+        }
+
+        Log("[LuaOpt] detection surface published on L=0x%08X",
+            (unsigned)(uintptr_t)L);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        Log("[LuaOpt] EXCEPTION in PublishDetectionSurface");
+    }
+}
+
+
 static void SetupLuaInterface(lua_State* L) {
     if (!Api.FrameScript_Execute) {
         if (Api.lua_pushboolean && Api.lua_setfield) {
@@ -1185,6 +1228,11 @@ static void DoMainThreadInit() {
 
     Log("[LuaOpt] lua_State* = 0x%08X", (unsigned)(uintptr_t)Api.L);
 
+    // Publish minimal detection surface before heavy init runs. Defensive:
+    // makes the !LuaBoost addon's hasDLL() succeed even if a later step
+    // (allocator replace, GC tune, FrameScript) faults.
+    PublishDetectionSurface(Api.L);
+
     bool allocOk = ReplaceLuaAllocator(Api.L);
     bool gcOk = OptimizeGC(Api.L);
     bool strOk = PreSizeStringTable(Api.L);
@@ -1230,6 +1278,82 @@ static void DoMainThreadInit() {
     Log("[LuaOpt] ====================================");
 }
 
+// ================================================================
+//  FrameScript_Execute hook — synchronous lua_State swap detector
+//
+// WHAT: MinHook trampoline on FrameScript_Execute. On every entry,
+//       check whether *0x00D3F78C has changed since we last saw it;
+//       if so, run PublishDetectionSurface against the new state
+//       BEFORE calling the original.
+// WHY:  OnMainThreadSleep only fires when the main thread actually
+//       sleeps. During the post-enter-world loading screen the main
+//       thread can stay busy for 5+ seconds, so a fast user clicks
+//       through to PLAYER_LOGIN (which fires through this exact
+//       FrameScript_Execute call path) before our publish has a
+//       chance to land. The addon's hasDLL() then reads nil and
+//       commits to its Lua-side ThrashGuard fallback.
+//
+//       The hook turns the publish into a synchronous,
+//       happens-before-PLAYER_LOGIN guarantee: any Lua chunk WoW or
+//       an addon executes forces our publish first, on whichever
+//       lua_State is current right now.
+// ================================================================
+static fn_FrameScript_Execute orig_FrameScript_Execute = nullptr;
+static lua_State* g_fsHookLastSeenL = nullptr;
+static bool g_fsHookActive = false;
+
+static void __cdecl Hooked_FrameScript_Execute(const char* code, const char* source, int unknown) {
+    static thread_local bool s_inHook = false;
+
+    if (!s_inHook) {
+        s_inHook = true;
+        __try {
+            lua_State* curL = ReadLuaState();
+            if (curL && curL != g_fsHookLastSeenL) {
+                g_fsHookLastSeenL = curL;
+                PublishDetectionSurface(curL);
+            }
+        } __except (EXCEPTION_EXECUTE_HANDLER) {
+            Log("[LuaOpt] EXCEPTION in FrameScript_Execute hook");
+        }
+        s_inHook = false;
+    }
+
+    if (orig_FrameScript_Execute) {
+        orig_FrameScript_Execute(code, source, unknown);
+    }
+}
+
+static void InstallFrameScriptExecuteHook() {
+    if (g_fsHookActive) return;
+    if (!Api.FrameScript_Execute) {
+        Log("[LuaOpt] FrameScript_Execute hook: skipped (target not resolved)");
+        return;
+    }
+
+    if (MH_CreateHook((void*)Api.FrameScript_Execute,
+                      (void*)Hooked_FrameScript_Execute,
+                      (void**)&orig_FrameScript_Execute) != MH_OK) {
+        Log("[LuaOpt] FrameScript_Execute hook: MH_CreateHook failed");
+        return;
+    }
+
+    if (MH_EnableHook((void*)Api.FrameScript_Execute) != MH_OK) {
+        Log("[LuaOpt] FrameScript_Execute hook: MH_EnableHook failed");
+        return;
+    }
+
+    // Route Api.FrameScript_Execute through the trampoline so our own
+    // PublishDetectionSurface / SetupLuaInterface calls invoke the
+    // original directly and don't re-enter the hook (the s_inHook
+    // recursion guard already handles re-entry, but skipping the
+    // extra branch is cheaper).
+    Api.FrameScript_Execute = orig_FrameScript_Execute;
+
+    g_fsHookActive = true;
+    Log("[LuaOpt] FrameScript_Execute hook: ACTIVE (synchronous lua_State swap detection)");
+}
+
 namespace LuaOpt {
 
 bool PrepareFromWorkerThread() {
@@ -1257,6 +1381,8 @@ bool PrepareFromWorkerThread() {
     } else {
         Log("[LuaOpt] lua_State* = NULL (will retry on main thread)");
     }
+
+    InstallFrameScriptExecuteHook();
 
     g_addressesValid = true;
     InterlockedExchange(&g_luaInitState, 1);
@@ -1290,6 +1416,14 @@ void OnMainThreadSleep(DWORD mainThreadId, double frameMs) {
                                            : LUA_RELOAD_SETTLE_FRAMES_SINGLE;
 
         if (currentL != g_pendingLuaState) {
+            // Close the !LuaBoost detection race during the settle window:
+            // publish LUABOOST_DLL_LOADED + LuaBoostC_IsLoaded onto the new
+            // state *now*, before we wait 50 ms / 2 frames for the heavy
+            // SetupLuaInterface re-run. PLAYER_LOGIN often fires inside
+            // that window; without this, hasDLL() returns false and the
+            // addon concludes the DLL is absent.
+            PublishDetectionSurface(currentL);
+
             g_pendingLuaState = currentL;
             g_pendingLuaStateTick = nowTick;
             g_pendingLuaStateFrames = 1;
@@ -1450,7 +1584,7 @@ Stats GetStats() {
     return s;
 }
 
-bool LuaOpt::IsLoadingMode() {
+bool IsLoadingMode() {
     return Config.isLoading;
 }
 

--- a/src/version_proxy.cpp
+++ b/src/version_proxy.cpp
@@ -133,7 +133,19 @@ __declspec(dllexport) DWORD WINAPI Export_VerLanguageNameW(DWORD a, LPWSTR b, DW
 // Loader thread
 // ================================================================
 static DWORD WINAPI LoaderThread(LPVOID param) {
-    Sleep(3000);
+    // Brief defensive delay before LoadLibrary'ing wow_optimize.dll. The
+    // original value was Sleep(3000) (since the proxy's first commit, no
+    // documented rationale). Three seconds is long enough that a fast-
+    // logging user can be in the world before our DLL is even loaded —
+    // !LuaBoost's PLAYER_LOGIN handler then runs hasDLL() against globals
+    // that don't exist yet, the addon installs its Lua-side ThrashGuard
+    // fallback, and `/lb` shows "wow_optimize.dll: NOT DETECTED".
+    //
+    // 100 ms is enough for the Wine/Windows PE loader to release the
+    // loader lock and for WoW.exe's CRT init to progress past anything
+    // the original 3 s might have been waiting for, while keeping us
+    // injected before any plausible enter-world path completes.
+    Sleep(100);
 
     char dllPath[MAX_PATH];
     char modulePath[MAX_PATH];


### PR DESCRIPTION
User-visible problem
====================
The !LuaBoost companion addon's `/lb` slash command prints a status block to the chat frame. One of its lines reads either:

    wow_optimize.dll: CONNECTED       (green — addon sees the DLL)
    wow_optimize.dll: NOT DETECTED    (grey — addon does not)

Users on Project Epoch (3.3.5a) reported NOT DETECTED appearing intermittently after entering the world or running /reload. The same predicate (hasDLL()) is consulted from several places — the `/lb` status print, the PLAYER_LOGIN summary line, and the ThrashGuard install gate — and when it returns false the addon silently switches to its Lua-side ThrashGuard fallback ("ACTIVE (N hooks, X% skip rate)" in the same status block) instead of trusting the DLL's C-level hooks. That fallback costs CPU per frame and partially defeats the optimisation. The "randomness" turned out to be timing-dependent: a fast user clicking through to "Enter World" hit the bug; a slower user did not.

Root cause — three stacked races
================================
The addon's hasDLL() predicate (!LuaBoost/LuaBoost.lua:610-612):

    type(_G.LuaBoostC_IsLoaded) == "function"
        and _G.LUABOOST_DLL_LOADED == true

Both globals are written together by SetupLuaInterface(L), which historically only ran via the OnMainThreadSleep path: a Sleep hook that fires only when the main thread genuinely calls Sleep. Three separate timing races could leave hasDLL() false at addon-check time:

  Race 1a — version.dll proxy delay
    src/version_proxy.cpp's LoaderThread (the worker spawned from
    version.dll DllMain to LoadLibraryA wow_optimize.dll) opened
    with Sleep(3000). Affects only users whose injection path goes
    through the version.dll proxy. No documented rationale; in the
    file since the proxy's first commit.

  Race 1b — wow_optimize.dll MainThread startup delay  ← load-bearing
    src/dllmain.cpp's MainThread (the worker spawned from this
    DLL's own DllMain that performs all hooking and init) opened
    with Sleep(5000). Affects every injection path, including the
    wow_loader.exe external-injector path that bypasses the
    version.dll proxy entirely. No documented rationale; in the
    file since v1.0 (33a709e). For the maintainer's setup
    (wow_loader.exe), this is *the* race window:

        T+0s    wow_loader.exe injects wow_optimize.dll
        T+0s    DllMain spawns MainThread
        T+0s    MainThread enters Sleep(5000)
        T+0..5s User clicks through realm + character select
        T+~5s   MainThread wakes; LogOpen; MinHook installs every
                hook including the FrameScript_Execute trampoline

    If the user finishes "Enter World" inside the 5 s window,
    none of our hooks exist yet, the world-state lua_State swap
    goes undetected, !LuaBoost's PLAYER_LOGIN handler runs
    hasDLL() against globals that don't exist, and `/lb` reports
    NOT DETECTED for the rest of the session.

  Race 2 — post-injection main-thread Sleep starvation
    Even after every hook is installed, our publish only ran when
    OnMainThreadSleep fired, which depends on the main thread
    actually calling Sleep. During the post-enter-world loading
    screen the main thread can stay busy for 5+ seconds. A typical
    captured timeline:

        [15:39:38.707] published on L=0x04FB85F8 (Glue)
        [15:39:45.900] published on L=0x0875ABE8 (world)
        [15:39:45.900] lua_State changed - waiting for new VM to settle
        [15:39:51.182] reinitializing stable VM            (+5.28 s later)

    Settle dominated by Sleep starvation, not by the 50 ms /
    2-frame threshold. PLAYER_LOGIN routinely fires inside the gap.

Fix — four parts
================

1. Shrink version-proxy LoaderThread delay 3000 ms -> 100 ms (src/version_proxy.cpp). 100 ms is enough for the PE loader to release the loader lock acquired during version.dll DllMain and for WoW.exe's CRT init to settle past whatever ambient races the original 3 s might have been guarding against (none of which were documented). Firmly inside any plausible enter-world path, so no fast login can outrun the LoaderThread on the proxy path.

2. Shrink wow_optimize.dll MainThread startup delay 5000 ms -> 100 ms (src/dllmain.cpp). Same reasoning as (1) but on the in-DLL worker thread that runs all hook installation. This is the critical fix for users injecting via wow_loader.exe (or any future injector that bypasses the version.dll proxy) — without it, the hooks installed by parts (3) and (4) below are not yet active when fast logins reach PLAYER_LOGIN, and the rest of the commit cannot help.

3. New PublishDetectionSurface(L) helper (src/lua_optimize.cpp). Writes the minimum the addon's hasDLL() actually checks: LUABOOST_DLL_LOADED via lua_pushboolean+lua_setfield, and LuaBoostC_IsLoaded via a one-line FrameScript_Execute snippet. Wrapped in __try/__except so a half-built lua_State surfaces as a logged SEH crash rather than an unhandled AV. Idempotent — SetupLuaInterface later overwrites LuaBoostC_IsLoaded with its full FrameScript-defined version along with the rest of the LuaBoostC_* surface (GetStats, GCStep, GCCollect, SetCombat, GCMemory, GetUIStats, GetApiStats, GetFastPathStats).

   Wired into: * DoMainThreadInit (cold-launch path, defensive). * OnMainThreadSleep at the first observation of a new lua_State, before the existing settle wait. Closes the OnMainThreadSleep-driven detection blackout.

4. MinHook trampoline on FrameScript_Execute (src/lua_optimize.cpp). Every Lua chunk WoW or an addon runs (including the chunks that drive PLAYER_LOGIN dispatch and !LuaBoost's own load) goes through this function. On hook entry:

     a. Read *0x00D3F78C (the current lua_State pointer).
     b. If it differs from our last-seen pointer, run
        PublishDetectionSurface against the new state BEFORE
        delegating to the original FrameScript_Execute.

   This gives a happens-before guarantee: by the time any addon code can read _G.LuaBoostC_IsLoaded, our publish has already landed. Closes Race 2 even when OnMainThreadSleep is starved for seconds.

Recursion safety for the hook
=============================
PublishDetectionSurface itself calls FrameScript_Execute (to install LuaBoostC_IsLoaded as a Lua function). Two layered guards prevent recursion:

  * thread_local s_inHook bool — re-entry on the same thread skips the swap check and goes straight to the original.
  * After MH_EnableHook, we rebind Api.FrameScript_Execute to point at the trampoline's "original" pointer. All in-DLL calls (PublishDetectionSurface, SetupLuaInterface) bypass the hook entirely. Defence in depth — either guard alone would suffice.

Logging
=======
Three new lines at __info__ level, all rare in steady state:

  * `[LuaOpt] FrameScript_Execute hook: ACTIVE (...)` Once at PrepareFromWorkerThread time, alongside other status.
  * `[LuaOpt] detection surface published on L=0x...` Once per lua_State swap (~3 swaps per session — Glue, world, occasional UI re-init).
  * `[LuaOpt] EXCEPTION in PublishDetectionSurface` Only on real SEH crashes (none observed in testing).

What is unchanged
=================
OnMainThreadSleep continues to drive the heavy reinit (allocator/GC/string-table/full SetupLuaInterface) on lua_State swap. The hook only handles the *detection-surface* publish — the small subset that the addon's hasDLL() actually checks. Once the main thread eventually sleeps, the existing settle-then-reinit machinery runs as before and overwrites our minimal publish with the full LuaBoostC_* surface. Settle constants, allocator/GC tuning, string-table presizing, and the order of feature installation in MainThread are all untouched — only the leading Sleep is shorter.

Considered alternatives
=======================
  * Direct lua_pushcclosure for LuaBoostC_IsLoaded (skip the FrameScript parser entirely). Tried with the address used in src/lua_fastpath.cpp:82 (0x0084E980); calling that address raises EXCEPTION_ILLEGAL_INSTRUCTION at runtime, so the address is wrong for build 12340 (the fastpath call site presumably never executes). Reverted; FrameScript_Execute install proven by the cold-launch and world-state probes (`loaded=yes, fn=yes` captured during testing) to work even on freshly-created lua_States, which contradicted my earlier silent-failure hypothesis. Finding the correct lua_pushcclosure address is a binary-disassembly task; out of scope here.
  * LoadLibrary directly from version.dll DllMain (skip the LoaderThread entirely). Would be synchronous and race-free against Race 1a, but DllMain holds the loader lock and LoadLibrary'ing a hook-heavy DLL from there can deadlock. The deferred-thread pattern is the right shape; just not three seconds.
  * Hook installation directly in DllMain (skip MainThread). Same loader-lock deadlock concern. The deferred-thread pattern is correct for Race 1b too; just not five seconds.

Confirmed working across the timing spectrum (slow + fast logins).

Drive-by cleanup
================
src/lua_optimize.cpp had a redundant `bool LuaOpt::IsLoadingMode()` qualifier on a definition already inside `namespace LuaOpt { ... }`. clang-cl flagged it under -Wextra-qualification. Trivial to fix while in this file; no behaviour change.