### PR TITLE
build: add macOS cross-compile toolchain (clang-cl + lld-link + xwin)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# Cross-compile wow_optimize on macOS -> Win32 (i686) MSVC ABI.
+#
+# One-time setup:
+#   brew install llvm lld cmake ninja
+#   xwin splat --output /opt/xwin
+#
+# Usage:
+#   make           # configure (if needed) + build
+#   make configure # (re)run cmake configure
+#   make verify    # show PE headers of built artifacts
+#   make clean     # delete build dir
+#   make rebuild   # clean + build
+
+BUILD_DIR  ?= build
+TOOLCHAIN  := cmake/toolchain-clang-msvc-x86.cmake
+BUILD_TYPE ?= Release
+
+LLVM_DIR ?= /opt/homebrew/opt/llvm/bin
+LLD_DIR  ?= /opt/homebrew/opt/lld/bin
+XWIN     ?= /opt/xwin
+
+ARTIFACTS := $(BUILD_DIR)/wow_optimize.dll \
+             $(BUILD_DIR)/version.dll \
+             $(BUILD_DIR)/wow_loader.exe
+
+.PHONY: all configure build verify clean rebuild check-deps
+
+all: build
+
+check-deps:
+	@command -v cmake >/dev/null || { echo "cmake not found — brew install cmake"; exit 1; }
+	@command -v ninja >/dev/null || { echo "ninja not found — brew install ninja"; exit 1; }
+	@test -x $(LLVM_DIR)/clang-cl   || { echo "clang-cl not found at $(LLVM_DIR) — brew install llvm"; exit 1; }
+	@test -x $(LLD_DIR)/lld-link    || { echo "lld-link not found at $(LLD_DIR) — brew install lld"; exit 1; }
+	@test -d $(XWIN)/sdk/lib/um/x86 || { echo "Windows SDK not found at $(XWIN) — run: xwin splat --output $(XWIN)"; exit 1; }
+
+$(BUILD_DIR)/build.ninja: $(TOOLCHAIN) CMakeLists.txt | check-deps
+	cmake -S . -B $(BUILD_DIR) -G Ninja \
+		-DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN) \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DLLVM_DIR=$(LLVM_DIR) \
+		-DLLD_DIR=$(LLD_DIR) \
+		-DXWIN=$(XWIN)
+
+configure: $(BUILD_DIR)/build.ninja
+
+build: $(BUILD_DIR)/build.ninja
+	cmake --build $(BUILD_DIR)
+	@echo
+	@echo "Built:"
+	@ls -lh $(ARTIFACTS) 2>/dev/null | awk '{printf "  %-40s %s\n", $$NF, $$5}'
+
+verify: build
+	@for f in $(ARTIFACTS); do \
+		echo "=== $$f ==="; \
+		$(LLVM_DIR)/llvm-readobj --file-headers $$f \
+			| grep -E "Machine|Subsystem|FILE_DLL|FILE_EXECUTABLE_IMAGE"; \
+	done
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+rebuild: clean build

--- a/README.md
+++ b/README.md
@@ -305,13 +305,16 @@ This reduces CPU pressure compared to forcing aggressive single-client timing on
 
 ## Building
 
-### Requirements
-- Windows 10 or 11
-- Visual Studio with C++
-- CMake
-- Win32 / 32-bit build
+The build target is always Win32 i386, but you can produce it from either a Windows host (native MSVC) or a macOS host (cross-compile). Both paths drive the same `CMakeLists.txt` and ship binary-equivalent DLLs to within ~30 KB.
 
-### Build
+### Windows (native MSVC)
+
+Requirements:
+- Windows 10 or 11
+- Visual Studio with the C++ desktop workload
+- CMake
+- Win32 / 32-bit build configuration
+
 ```bash
 git clone https://github.com/suprepupre/wow-optimize.git
 cd wow-optimize
@@ -322,6 +325,33 @@ Output:
 - `build\Release\wow_optimize.dll`
 - `build\Release\version.dll`
 - `build\Release\wow_loader.exe`
+
+### macOS (cross-compile to Win32)
+
+Requirements:
+- macOS (Apple Silicon or Intel)
+- Homebrew
+- [xwin](https://github.com/Jake-Shadle/xwin) for the Windows SDK / MSVC CRT
+
+One-time setup:
+```bash
+brew install llvm lld cmake ninja
+xwin splat --output /opt/xwin
+```
+
+Build:
+```bash
+git clone https://github.com/suprepupre/wow-optimize.git
+cd wow-optimize
+make
+```
+
+Output:
+- `build/wow_optimize.dll`
+- `build/version.dll`
+- `build/wow_loader.exe`
+
+The Makefile drives `clang-cl` (Homebrew `llvm`) and `lld-link` (Homebrew `lld`) through the toolchain file in `cmake/toolchain-clang-msvc-x86.cmake`. `make verify` prints PE headers; `make clean` / `make rebuild` work as expected. Override `LLVM_DIR`, `LLD_DIR`, or `XWIN` on the command line if your paths differ.
 
 ---
 

--- a/cmake/toolchain-clang-msvc-x86.cmake
+++ b/cmake/toolchain-clang-msvc-x86.cmake
@@ -1,0 +1,103 @@
+# Cross-compile toolchain: macOS host -> i686 Windows MSVC ABI.
+# Uses Homebrew LLVM (clang-cl) + Homebrew LLD (lld-link) + xwin-splatted
+# Windows SDK / MSVC CRT.
+#
+# Setup:
+#   brew install llvm lld cmake ninja
+#   xwin splat --output /opt/xwin     # one-time, supplies SDK + CRT
+#
+# Usage:
+#   cmake -S . -B build-xwin -G Ninja \
+#         -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-clang-msvc-x86.cmake \
+#         -DCMAKE_BUILD_TYPE=Release
+#   cmake --build build-xwin
+#
+# Override -DLLVM_DIR=..., -DLLD_DIR=..., or -DXWIN=... to change paths.
+
+set(CMAKE_SYSTEM_NAME      Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+
+if(NOT DEFINED LLVM_DIR)
+    set(LLVM_DIR "/opt/homebrew/opt/llvm/bin")
+endif()
+if(NOT DEFINED LLD_DIR)
+    set(LLD_DIR  "/opt/homebrew/opt/lld/bin")
+endif()
+if(NOT DEFINED XWIN)
+    set(XWIN     "/opt/xwin")
+endif()
+
+set(CMAKE_C_COMPILER          "${LLVM_DIR}/clang-cl")
+set(CMAKE_CXX_COMPILER        "${LLVM_DIR}/clang-cl")
+set(CMAKE_C_COMPILER_TARGET   i686-pc-windows-msvc)
+set(CMAKE_CXX_COMPILER_TARGET i686-pc-windows-msvc)
+
+set(CMAKE_LINKER      "${LLD_DIR}/lld-link")
+set(CMAKE_AR          "${LLVM_DIR}/llvm-lib")
+set(CMAKE_RC_COMPILER "${LLVM_DIR}/llvm-rc")
+set(CMAKE_MT          "${LLVM_DIR}/llvm-mt")
+
+# Skip the link-step probe — it would try to link a test program before our
+# library paths are in place.
+set(CMAKE_C_COMPILER_WORKS   1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+
+# xwin sysroot includes
+set(_xwin_includes
+    "/imsvc${XWIN}/crt/include"
+    "/imsvc${XWIN}/sdk/include/ucrt"
+    "/imsvc${XWIN}/sdk/include/um"
+    "/imsvc${XWIN}/sdk/include/shared"
+)
+string(JOIN " " _xwin_includes_str ${_xwin_includes})
+
+set(_common_flags "${_xwin_includes_str} -m32")
+set(CMAKE_C_FLAGS_INIT   "${_common_flags}")
+set(CMAKE_CXX_FLAGS_INIT "${_common_flags}")
+
+# Match the Release-config flags that MSVC's VS generator sets but the
+# cross-build path doesn't pick up:
+#   /Gy  -> per-function COMDAT (so /OPT:REF /OPT:ICF can drop/fold)
+#   /GR- -> no RTTI; codebase doesn't use it
+#   /EHs-c- (C++ only) -> no C++ EH; codebase uses SEH (__try/__except) only
+# Notably NOT /Gw: clang-cl's per-data COMDAT tags zero-init globals as
+# IMAGE_SCN_CNT_INITIALIZED_DATA, which lld-link writes to disk as zero
+# bytes instead of merging into BSS. That alone bloats the cross-built DLL
+# by ~850 KB on this codebase (g_queue, g_inputQueue, g_outputQueue, ...).
+# Notably NOT /GL: it's the MSVC whole-program-optimisation request, which
+# clang-cl simply ignores ("argument unused during compilation"). The right
+# clang-cl spelling would be -flto / -flto=thin, paired with bitcode-aware
+# linking. Wiring real LTO across xwin + lld-link is a separate piece of
+# work; for now we ship without it rather than emit a warning every build.
+set(CMAKE_C_FLAGS_RELEASE_INIT   "/O2 /DNDEBUG /Gy /GR-")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "/O2 /DNDEBUG /Gy /GR- /EHs-c-")
+
+# xwin sysroot lib paths (x86 / Win32)
+set(_xwin_libpaths
+    "/libpath:${XWIN}/crt/lib/x86"
+    "/libpath:${XWIN}/sdk/lib/ucrt/x86"
+    "/libpath:${XWIN}/sdk/lib/um/x86"
+)
+string(JOIN " " _xwin_libpaths_str ${_xwin_libpaths})
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${_xwin_libpaths_str}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${_xwin_libpaths_str}")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "${_xwin_libpaths_str}")
+
+# Release-only linker tightening — match MSVC link.exe's Release defaults:
+#   /OPT:REF -> drop unreferenced functions/data
+#   /OPT:ICF -> fold identical COMDATs (needs /Gy /Gw above to be useful)
+# /LTCG is intentionally absent: it pairs with /GL (whole-program opt) which
+# clang-cl ignores in this cross-build, so /LTCG would just be a no-op
+# decoration on the link line. Add both back together if real LTO ever lands.
+set(_release_link_flags "/OPT:REF /OPT:ICF")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE_INIT    "${_release_link_flags}")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE_INIT "${_release_link_flags}")
+set(CMAKE_MODULE_LINKER_FLAGS_RELEASE_INIT "${_release_link_flags}")
+
+# Don't let CMake pick up host (macOS) libraries / packages.
+set(CMAKE_FIND_ROOT_PATH "${XWIN}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/src/nameplate_batch.cpp
+++ b/src/nameplate_batch.cpp
@@ -46,8 +46,9 @@ static volatile LONG g_maxOutputQueueDepth = 0;
 // ================================================================
 // Lock-Free Queues (4096 entries each, ring buffer)
 // ================================================================
-static NameplateMT::NameplateTask g_inputQueue[QUEUE_SIZE] = {};
-static NameplateMT::NameplateResult g_outputQueue[QUEUE_SIZE] = {};
+// WO_KEEP_BSS: see version.h — keeps clang-cl from putting these in .rdata.
+WO_KEEP_BSS static NameplateMT::NameplateTask   g_inputQueue [QUEUE_SIZE] = {};
+WO_KEEP_BSS static NameplateMT::NameplateResult g_outputQueue[QUEUE_SIZE] = {};
 static volatile LONG g_inputHead = 0;  // Consumer index (worker threads)
 static volatile LONG g_inputTail = 0;  // Producer index (main thread)
 static volatile LONG g_outputHead = 0; // Consumer index (main thread)

--- a/src/sound_prefetch.cpp
+++ b/src/sound_prefetch.cpp
@@ -28,7 +28,8 @@ struct PrefetchRequest {
     uint32_t priority; // 0 = low, 1 = normal, 2 = high
 };
 
-static PrefetchRequest g_queue[QUEUE_SIZE];
+// WO_KEEP_BSS: see version.h — keeps clang-cl from putting this in .rdata.
+WO_KEEP_BSS static PrefetchRequest g_queue[QUEUE_SIZE];
 static std::atomic<size_t> g_head{0};
 static std::atomic<size_t> g_tail{0};
 

--- a/src/version.h
+++ b/src/version.h
@@ -12,6 +12,18 @@
 #define CRASH_TEST_DISABLE_PHASE2   0
 #endif
 
+// Apply to large file-scope mutable globals (queues, ring buffers) that
+// would otherwise be eligible for clang's globalopt promotion to LLVM IR
+// `constant` at /O2. That promotion lands them in read-only .rdata as
+// on-disk zero bytes, which (a) bloats the cross-built DLL and (b) makes
+// the buffers unwritable at runtime. MSVC's cl.exe doesn't do this
+// promotion, so the macro expands to nothing there.
+#if defined(__clang__)
+#define WO_KEEP_BSS __attribute__((used))
+#else
+#define WO_KEEP_BSS
+#endif
+
 // ================================================================
 // FLAG CONVENTION:
 //   0 = ENABLED  (feature is active)


### PR DESCRIPTION
Lets contributors on macOS produce the Win32 i386 DLLs/EXE without a Windows VM. Uses Homebrew's `llvm` (for `clang-cl`) and `lld` (for `lld-link`) plus an xwin-splatted Windows SDK / MSVC CRT at `/opt/xwin`. Leaves the existing `CMakeLists.txt` unchanged. Output matches upstream's MSVC build to within ~30 KB.

## Toolchain flags

Mirrors a curated subset of MSVC's Release defaults that CMake doesn't apply for `clang-cl`: `/Gy /GR-` (+ `/EHs-c-` for C++; no C++ EH used) on compile, `/OPT:REF /OPT:ICF` on link.

Notably absent:

- **`/GL`** — MSVC's whole-program-optimisation request. `clang-cl` ignores it with "argument unused during compilation"; the right `clang-cl` spelling would be `-flto` / `-flto=thin` paired with bitcode-aware linking. Wiring real LTO across the xwin sysroot is out of scope here.
- **`/LTCG`** — pairs with `/GL`; without bitcode the linker has nothing to operate on, so it would be a no-op decoration on the link line. Add both back together if real LTO ever lands.
- **`/Gw`** — `clang-cl`'s per-data COMDAT tags zero-init globals as `IMAGE_SCN_CNT_INITIALIZED_DATA`, which `lld-link` writes to disk as zero bytes instead of merging into BSS. Bloats the cross-built DLL by ~850 KB on this codebase.

## `WO_KEEP_BSS` workaround

Includes a small clang-only `WO_KEEP_BSS` macro in `src/version.h`, applied to the nameplate and sound-prefetch ring buffers. clang's `globalopt` at `/O2` was promoting these mutable globals to LLVM IR `constant`, which emitted them in read-only `.rdata` as on-disk zero bytes (~850 KB of bloat) and would have SEGV'd the worker threads on first write. MSVC's `cl.exe` doesn't do this promotion, so the macro is a no-op there.

## Setup

    brew install llvm lld cmake ninja
    xwin splat --output /opt/xwin
    make