### PR TITLE
fix: ignore 0xC000001D probe inside ClientExtensions.dll in crash dumper

### DIFF
--- a/src/crash_dumper.cpp
+++ b/src/crash_dumper.cpp
@@ -1,6 +1,7 @@
 #include <windows.h>
 #include <dbghelp.h>
 #include <cstdio>
+#include <cstring>
 #include <ctime>
 #include "version.h"
 
@@ -30,6 +31,40 @@ static LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS* ExceptionInfo) {
         code == EXCEPTION_SINGLE_STEP ||         // Single step (debugger)
         code == EXCEPTION_DATATYPE_MISALIGNMENT) { // Alignment fault (handled)
         return EXCEPTION_CONTINUE_SEARCH;
+    }
+
+    // Anti-debug / anti-tamper probe inside ClientExtensions.dll (Project
+    // Epoch). It raises a deterministic EXCEPTION_ILLEGAL_INSTRUCTION at
+    // ClientExtensions+0x11fc42 every launch and resolves it via its own
+    // __except frame at step 3 of the Win32 dispatch chain. Our VEH (step 2)
+    // fires first and would otherwise write a misleading minidump every run.
+    //
+    // Observed only on macOS / Wine so far; native Windows behaviour is
+    // unverified, so the filter may be a no-op there. The module-identity
+    // check makes the no-op case harmless.
+    //
+    // Only filter when the faulting address resolves to ClientExtensions.dll —
+    // genuine illegal-instruction crashes anywhere else (Wow.exe, our DLL, any
+    // other loaded PE, or MEM_PRIVATE shellcode pages) still produce a dump.
+    // GetModuleHandleEx with FROM_ADDRESS|UNCHANGED_REFCOUNT is safe from a VEH:
+    // no allocations, no callbacks, no refcount mutation.
+    if (code == EXCEPTION_ILLEGAL_INSTRUCTION) {
+        HMODULE hMod = NULL;
+        if (GetModuleHandleExA(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                (LPCSTR)ExceptionInfo->ExceptionRecord->ExceptionAddress,
+                &hMod) && hMod != NULL) {
+            char path[MAX_PATH];
+            DWORD n = GetModuleFileNameA(hMod, path, sizeof(path));
+            if (n > 0 && n < sizeof(path)) {
+                const char* base = strrchr(path, '\\');
+                base = base ? base + 1 : path;
+                if (_stricmp(base, "ClientExtensions.dll") == 0) {
+                    return EXCEPTION_CONTINUE_SEARCH;
+                }
+            }
+        }
     }
     
     // Set flag before processing to prevent re-entry


### PR DESCRIPTION
## User-visible problem

Every launch on Project Epoch (3.3.5a) wrote a spurious minidump and a misleading "CRASH" line to `Logs/wow_optimize.log`:

    [11:44:32.379] CRASH: 0xC000001D at 0x728C27CA.
                   Dump written to Crashes\wow_crash_20260427_114431.dmp

The process kept running normally — the line was a lie. The dump itself is small (single-digit KB), but `Crashes/` accumulated one bogus file per launch, polluting the directory users open expecting real crash artifacts. Genuine bug reports lost signal under the noise; reviewers and triagers had to hand-filter the ClientExtensions false positive every time.

**Reproduction environment:** observed and reliably reproduced on macOS under Wine — the maintainer's setup. Native Windows behaviour is unverified; the trigger may be specific to Wine's exception-dispatch implementation (the order in which Wine surfaces a first-chance exception to a VEH vs. a frame `__except`) rather than to the protector itself. The fix is platform-agnostic — it filters on module identity at the VEH, which behaves the same on either dispatcher — so applying it on native Windows is safe regardless of whether the false positive actually fires there.

## Root cause

Project Epoch's `ClientExtensions.dll` deterministically raises `EXCEPTION_ILLEGAL_INSTRUCTION` (`0xC000001D`) at a fixed module-relative offset (`+0x11fc42`; runtime address `~0x728C27CA` in the latest log) and resolves it via its own `__except` frame at step 3 of the Win32 exception dispatch chain. We do not know *why* it does this — most likely some form of anti-debug or anti-tamper probe — but empirically the handler runs every launch and the process is fine afterwards.

Our crash dumper installs a Vectored Exception Handler at priority 1, which fires at step 2 — before any frame-based handler claims the exception. The dumper therefore sees every first-chance exception, including ClientExtensions's handled probe, and dumps it.

## Fix

Filter surgically by *module identity*, not by exception code alone: skip `0xC000001D` iff `GetModuleHandleEx(FROM_ADDRESS)` resolves the faulting address to a module whose basename is `ClientExtensions.dll`.

- Genuine illegal-instruction crashes anywhere else — `Wow.exe`, our own DLL, any other loaded PE, `MEM_PRIVATE` shellcode pages — still produce a dump.
- Genuine illegal-instruction crashes inside `ClientExtensions.dll` itself are no longer dumped. We accept that trade: it is third-party closed-source code we cannot symbolicate or fix; if a real bug there ever matters, the address still surfaces via Windows' default exception dispatch.

`GetModuleHandleEx` with `FROM_ADDRESS|UNCHANGED_REFCOUNT` is documented safe from a VEH (no allocations, no callbacks, no refcount mutation). No new linker inputs.

## Considered alternatives

- **Blanket whitelist of `EXCEPTION_ILLEGAL_INSTRUCTION` (no module check)** — would also drop genuine illegal-instruction crashes anywhere in the process. The module-conditional form keeps that signal.
- **`AddVectoredContinueHandler` in place of the existing VEH** — wrong: VCH only fires when a frame handler returned `EXCEPTION_CONTINUE_EXECUTION`, not on truly unhandled exceptions; we would lose dumps for real crashes.
- **`SetUnhandledExceptionFilter` in place of the existing VEH** — fires only after SEH frame walk and would correctly skip ClientExtensions's handled probe, but changes dispatch semantics for the whole DLL (some `__fastfail` / `abort` paths bypass UEF; in-process `__except` blocks would silently eat exceptions before we see them). Worth evaluating on its own; out of scope for this commit.

## Verification

Cold-launch on Project Epoch (macOS / Wine; the only environment where the false positive has been observed); tail `Logs/wow_optimize.log`; confirm absence of the `CRASH: 0xC000001D` line and that `Crashes/` does not gain a new file. As a regression check, trigger any other crash class and confirm a dump still produces.